### PR TITLE
added CheckValueInRange for BasePrice which prevents overflow

### DIFF
--- a/circuit/batch_create_user_circuit.go
+++ b/circuit/batch_create_user_circuit.go
@@ -64,6 +64,7 @@ func (b BatchCreateUserCircuit) Define(api API) error {
 	for i := 0; i < len(b.BeforeCexAssets); i++ {
 		CheckValueInRange(api, b.BeforeCexAssets[i].TotalEquity)
 		CheckValueInRange(api, b.BeforeCexAssets[i].TotalDebt)
+		CheckValueInRange(api, b.BeforeCexAssets[i].BasePrice)
 		cexAssets[i] = api.Add(api.Mul(b.BeforeCexAssets[i].TotalEquity, utils.Uint64MaxValueFrSquare),
 			api.Mul(b.BeforeCexAssets[i].TotalDebt, utils.Uint64MaxValueFr), b.BeforeCexAssets[i].BasePrice)
 		afterCexAssets[i] = b.BeforeCexAssets[i]


### PR DESCRIPTION
Yesterday I discovered a bug in circuit which allows to bypass `api.AssertIsLessOrEqual(totalUserDebt, totalUserEquity)` assertion and generate fake user debt, which cannot by detected by 3th party. 

It is possible to bypass it, because there is a bug which allows setting BasePrice to very high value, there is no CheckValueInRange for this parameter. However, BasePrice is public for everyone, so it would be easy to detect if it’s invalid or not. But there is a way to do it in a way that will be impossible to detect by other users. 

Each proof is generated for batch of 864 users, then they’re linked with each other using the following poseidon hash:
```go
// verify whether befo// verify whether beforeCexAssetsCommitment is computed correctly
for i := 0; i < len(b.BeforeCexAssets); i++ {
	CheckValueInRange(api, b.BeforeCexAssets[i].TotalEquity)
	CheckValueInRange(api, b.BeforeCexAssets[i].TotalDebt)
	cexAssets[i] = api.Add(api.Mul(b.BeforeCexAssets[i].TotalEquity, utils.Uint64MaxValueFrSquare),
		api.Mul(b.BeforeCexAssets[i].TotalDebt, utils.Uint64MaxValueFr), b.BeforeCexAssets[i].BasePrice)
	afterCexAssets[i] = b.BeforeCexAssets[i]
}
actualCexAssetsCommitment := poseidon.Poseidon(api, cexAssets...)
```
So it is basically a combination of three parameters to one huge number: `(TotalEquity << 128) + (TotalDebt << 64) + BasePrice`.

Here’s how we can abuse it, let’s say that the BasePrice of the first asset is equal to 1000. After the 1st batch we have a TotalEquity equal 0 and TotalDebt equal 1 for the first asset. 
The following value will be used to generate hash of it: `(1 << 64) + (1000)`

In the 2nd batch, instead of sending TotalDebt equal 1, we send it equal to 0, but we also change the value of BasePrice to `(1 << 64) + 1000` which will give us the same Poseidon hash. Now we can use this huge BasePrice to fake user equity/assets, a single coin with such high base price will allow to fake debt of any other coin.

In the 3td batch, we just restore TotalDebt to 1 and BasePrice to 1000, it still gives the same, correct checksum. No one is able to detect that BasePrice was changed in the 2nd block.

Now let's say exchange is listing bitcoin and has 10000 equity, and 0  debt. By using this bug, they can fake 9000 bitcoins debt, so in the end they would need to show that they hold only 1000 bitcoins instead of 10000.

I demonstrated this issue in https://github.com/hknio/zkmerkle-proof-of-solvency-debt-bug repository

Fixes #4 